### PR TITLE
Update utils.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,7 @@ var installIfMissing = exports.installIfMissing = function(root, module) {
       require.resolve(location);
     } catch (e) {
       console.log('Installing ' + module);
-      return runCommand('npm', ['install', module, '--loglevel', 'error']).then(function () {
+      return runCommand('npm', ['install', module, '--ignore-scripts', '--loglevel', 'error']).then(function () {
         return previous;
       });
     }


### PR DESCRIPTION
installting donejs init fails on ubuntu vm. spawn-sync causes the error
added `--ignore-scripts` as a argument to install donejs-cli